### PR TITLE
Fix typo

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,5 +29,5 @@ if [ $ret -ne 0 ]; then
 fi
 
 echo "success=1" >> "$GITHUB_OUTPUT"
-echo "Script completed successfully
+echo "Script completed successfully"
 exit 0


### PR DESCRIPTION
I get failed builds because of a missing `"`, which appears to be this ...

```sh
/app/entrypoint.sh: line 32: unexpected EOF while looking for matching `"'
/app/entrypoint.sh: line 34: syntax error: unexpected end of file
```